### PR TITLE
Fix/refresh remember me on password change

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -10,8 +10,8 @@ framework:
     sid_length: 64
     sid_bits_per_character: 6
     name: __Host-sessionId
-    cookie_secure: true
-    cookie_samesite: lax
+    cookie_secure: '%app.auth_cookies_secure%'
+    cookie_samesite: '%app.auth_cookies_same_site%'
 
   #esi: true
   #fragments: true

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -29,8 +29,10 @@ security:
           - App\Security\AccountDeletionLogoutHandler
         csrf_token_generator: security.csrf.token_manager
       remember_me:
-        secret: '%kernel.secret%'
-        name: __Host-rememberMe
+        lifetime: '%app.remember_me_cookie_lifetime%'
+        name: '%app.remember_me_cookie_name%'
+        path: '%app.remember_me_cookie_path%'
+        secret: '%app.remember_me_cookie_secret%'
 
       # activate different ways to authenticate
       # https://symfony.com/doc/current/security.html#firewalls-authentication

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,10 +22,19 @@ parameters:
   app.argon2id_memory_cost: 128000 # Default is 65536
   app.argon2id_time_cost: 10 # Default is 4
 
+  # Applies to session and remember me cookies.
+  app.auth_cookies_same_site: lax
+  app.auth_cookies_secure: auto
+
   app.email_change_request_send_email_again_delay: 120 # seconds
   app.email_change_token_lifetime: 3600 # seconds
   app.password_reset_request_send_email_again_delay: 120 # seconds
   app.password_reset_token_lifetime: 3600 # seconds
+
+  app.remember_me_cookie_lifetime: 31556952 # 1 year in seconds
+  app.remember_me_cookie_path: /
+  app.remember_me_cookie_name: __Host-rememberMe
+  app.remember_me_cookie_secret: '%kernel.secret%'
 
 services:
   # default configuration for services in *this* file
@@ -80,6 +89,21 @@ services:
       $mailerAddress: '%env(MAILER_SENDER)%'
       $replyToAddress: '%env(MAILER_REPLY_TO)%'
       $websiteName: '%app.website_name%'
+
+  App\Service\RememberMeCookieService:
+    arguments:
+      $userProviders: ['@security.user.provider.concrete.users']
+      $secret: '%app.remember_me_cookie_secret%'
+      $providerKey: main
+      $options: {
+        lifetime: '%app.remember_me_cookie_lifetime%',
+        name: '%app.remember_me_cookie_name%',
+        path: '%app.remember_me_cookie_path%',
+        domain: null,
+        secure: '%app.auth_cookies_secure%',
+        httponly: true,
+        samesite: '%app.auth_cookies_same_site%'
+      }
 
   App\Twig\ArrayMergeRecursive:
     tags:

--- a/src/Controller/User/PasswordChangeController.php
+++ b/src/Controller/User/PasswordChangeController.php
@@ -5,6 +5,7 @@ namespace App\Controller\User;
 use App\Controller\DefaultController;
 use App\Form\User\PasswordChangeType;
 use App\Model\AbstractUser;
+use App\Service\RememberMeCookieService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -51,6 +52,7 @@ class PasswordChangeController extends DefaultController
      * Handles the password change form submitted with ajax.
      *
      * @param Request $request
+     * @param RememberMeCookieService $rememberMeCookieService
      * @param UserPasswordEncoderInterface $passwordEncoder
      * @param TranslatorInterface $translator
      * @Route("-ajax", name="password_change_ajax", methods="POST")
@@ -58,6 +60,7 @@ class PasswordChangeController extends DefaultController
      */
     public function change(
         Request $request,
+        RememberMeCookieService $rememberMeCookieService,
         UserPasswordEncoderInterface $passwordEncoder,
         TranslatorInterface $translator
     ): JsonResponse
@@ -72,6 +75,7 @@ class PasswordChangeController extends DefaultController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $hasValidRememberMeCookie = $rememberMeCookieService->hasValidCookie($request);
             $hashedPassword = $passwordEncoder->encodePassword($user, $user->getPlainPassword());
 
             $user->setPassword($hashedPassword);
@@ -88,9 +92,16 @@ class PasswordChangeController extends DefaultController
             ]);
             $jsonTemplate = json_encode($template->getContent());
 
-            return new JsonResponse([
+            $jsonResponse = new JsonResponse([
                 'template' => $jsonTemplate
             ], 200);
+
+            // Changing password invalids current remember me cookie so it must be refreshed.
+            if ($hasValidRememberMeCookie) {
+                $rememberMeCookieService->setCookie($jsonResponse, $user, $request);
+            }
+
+            return $jsonResponse;
         }
 
         // Renders and json encode the updated form (with errors)

--- a/src/Service/RememberMeCookieService.php
+++ b/src/Service/RememberMeCookieService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\RememberMe\TokenBasedRememberMeServices;
+
+/**
+ * Class RememberMeCookieService
+ *
+ * Allows to validate, generate or set a remember me cookie manually.
+ *
+ * @package App\Service
+ */
+class RememberMeCookieService extends TokenBasedRememberMeServices
+{
+    /**
+     * @param Request $request
+     * @return bool
+     */
+    public function hasValidCookie(Request $request): bool
+    {
+        return $this->autoLogin($request) instanceof RememberMeToken;
+    }
+
+    /**
+     * Sets remember me cookie in given $response.
+     *
+     * @param Response $response
+     * @param UserInterface $user
+     * @param Request $request
+     * @return Response
+     */
+    public function setCookie(Response $response, UserInterface $user, Request $request): Response
+    {
+        $response->headers->setCookie($this->generateCookie($user, $request));
+
+        return $response;
+    }
+
+    /**
+     * @param UserInterface $user
+     * @param Request $request
+     * @return Cookie
+     */
+    public function generateCookie(UserInterface $user, Request $request): Cookie
+    {
+        $expires = time() + $this->options['lifetime'];
+        $value = $this->generateCookieValue(get_class($user), $user->getUsername(), $expires, $user->getPassword());
+
+        return new Cookie(
+            $this->options['name'],
+            $value,
+            $expires,
+            $this->options['path'],
+            $this->options['domain'],
+            $this->options['secure'] ?? $request->isSecure(),
+            $this->options['httponly'],
+            false,
+            $this->options['samesite']
+        );
+    }
+}


### PR DESCRIPTION
Changing password invalids current remember me cookie so it must be refreshed.